### PR TITLE
fix: Add selectedExternalAssets to sync method promise

### DIFF
--- a/src/types/extensionRegistration/ExtensionRegistration.ts
+++ b/src/types/extensionRegistration/ExtensionRegistration.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Asset } from "../asset/Asset";
+import type { Asset, ExternalAssetSelection } from "../asset/Asset";
 
 export class ExtensionRegistrationError extends Error {
   constructor(message: string) {
@@ -113,9 +113,11 @@ export class ExtensionRegistrationService {
    * @param guestConnection - the guest connection
    * @returns the selected assets and the total count of left assets
    */
-  static selectContentExtensionSync(
-    guestConnection: any,
-  ): Promise<{ selectedAssets: Asset[], selectionLimit: number }> {
+  static selectContentExtensionSync(guestConnection: any): Promise<{
+    selectedAssets: Asset[];
+    selectedExternalAssets: ExternalAssetSelection;
+    selectionLimit: number;
+  }> {
     return guestConnection.host.api.selectContentExtension.sync();
   }
 }


### PR DESCRIPTION
## Description

Add `selectedExternalAssets` to the promise returned by `selectContentExtensionSync` in ExtensionRegistration.

## Related Issue

N/A

## Motivation and Context

We need to retrieve the selected external assets with the sync function, to toggle existing selections as selected, when an extension is registered.

## How Has This Been Tested?

Running locally.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.