### PR TITLE
feat: Add Supported locale schema and type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/uix-core": "^1.0.0",
-        "@adobe/uix-guest": "^1.0.0"
+        "@adobe/uix-guest": "^1.0.0",
+        "zod": "^3.25.64"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -9968,13 +9969,13 @@
       }
     },
     "node_modules/typedoc-plugin-zod": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-zod/-/typedoc-plugin-zod-1.3.1.tgz",
-      "integrity": "sha512-u4NH1Ez168gRNnhUd0x4pZhp85maJ9y050IxSok9XwdzTpUA9NN0ee3ho8ssrzmxsvO2UDbDEiks7xtI0p6UXA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-zod/-/typedoc-plugin-zod-1.4.1.tgz",
+      "integrity": "sha512-D7+uhPFCyKMcKnUSZip/BldE08Jo/yykvbxlIcY11fI8dKyCe23/igOiZ7rPW2mXD5N9kHEA2he9LkCoU+6HtA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "typedoc": "0.23.x || 0.24.x || 0.25.x || 0.26.x || 0.27.x"
+        "typedoc": "0.23.x || 0.24.x || 0.25.x || 0.26.x || 0.27.x || 0.28.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -10340,6 +10341,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@adobe/uix-core": "^1.0.0",
-    "@adobe/uix-guest": "^1.0.0"
+    "@adobe/uix-guest": "^1.0.0",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,3 +32,8 @@ export {
   ExtensionRegistrationService,
   ExtensionRegistrationError,
 } from "./types/extensionRegistration/ExtensionRegistration";
+
+export {
+  LocaleCode,
+  Locale,
+} from "./types/translation/locales";

--- a/src/types/translation/locales.ts
+++ b/src/types/translation/locales.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {z} from 'zod';
+
+export const localeCodeSchema = z
+  .string()
+  .regex(/^[a-z]{2}[a-zA-Z0-9\-_]*$/);
+
+export type LocaleCode = z.infer<typeof localeCodeSchema>;
+
+export type Locale = {
+  code: LocaleCode;
+  label: string;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -30,6 +30,8 @@ import {
   AdditionalContextTypes,
   AdditionalContext,
   SectionGenerationContext,
+  LocaleCode,
+  Locale,
 } from "../src";
 
 const TEST_EXTENSION_ID = "test-extension-id";
@@ -185,5 +187,14 @@ describe("SDK Exports", () => {
     expect(appMetaData.extensionId).toBe("test");
     expect(appMetaData.iconDataUri).toBe("test");
     expect(appMetaData.supportedChannels).toEqual([Email, Meta, Display]);
+  });
+
+  it("should export Locale types", () => {
+    const locale: Locale = {
+      code: "en-US",
+      label: "English (United States)",
+    };
+    expect(locale.code).toBe("en-US");
+    expect(locale.label).toBe("English (United States)");
   });
 });

--- a/tests/types/translation/locales.test.ts
+++ b/tests/types/translation/locales.test.ts
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {z} from 'zod';
+import { localeCodeSchema } from '../../../src/types/translation/locales';
+
+describe('Locale Types', () => {
+  describe('LocaleCode', () => {
+    const validCodes = [
+      'zh-CN',
+      'zh-TW',
+      'en-AU',
+      'en-GB',
+      'fr-FR',
+      'de-DE',
+      'it-IT',
+      'ja-JP',
+      'ko-KR',
+      'pt-BR',
+      'pt-PT',
+      'es-419',
+      'es-ES',
+      'th-TH',
+      'en_US',
+      'en-us',
+      'eng',
+      'en-',
+      'en--us'
+    ];
+
+    const invalidCodes = [
+      'EN',
+      'e',
+      '123',
+      '-en',
+      '',
+    ];
+
+    validCodes.forEach(code => {
+      it(`should accept valid locale code: ${code}`, () => {
+        expect(localeCodeSchema.safeParse(code).success).toBe(true);
+      });
+    });
+
+    invalidCodes.forEach(code => {
+      it(`should reject invalid locale code: ${code}`, () => {
+        expect(localeCodeSchema.safeParse(code).success).toBe(false);
+      });
+    });
+  });
+
+  describe('Locale', () => {
+    it('should accept valid locale object', () => {
+      const schema = z.object({
+        code: z.string().regex(/^[a-z]{2}[a-zA-Z0-9\-_]*$/),
+        label: z.string()
+      });
+
+      const validLocale = {
+        code: 'en-US',
+        label: 'English (United States)'
+      };
+
+      expect(schema.safeParse(validLocale).success).toBe(true);
+    });
+
+    it('should reject locale object with invalid code', () => {
+      const schema = z.object({
+        code: z.string().regex(/^[a-z]{2}[a-zA-Z0-9\-_]*$/),
+        label: z.string()
+      });
+
+      const invalidLocale = {
+        code: 'EN',
+        label: 'English (United States)'
+      };
+
+      expect(schema.safeParse(invalidLocale).success).toBe(false);
+    });
+
+    it('should reject locale object with missing required fields', () => {
+      const schema = z.object({
+        code: z.string().regex(/^[a-z]{2}[a-zA-Z0-9\-_]*$/),
+        label: z.string()
+      });
+
+      const invalidLocale = {
+        code: 'en-US'
+        // missing label
+      };
+
+      expect(schema.safeParse(invalidLocale).success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new schema and type for Supported Locale. 

A translation extension must define their list of locales using this type.

This is the type that GenStudio will expect when fetching the list of supported locales.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.