### PR TITLE
feat: Add iconUrl and extensionId to Asset type

### DIFF
--- a/src/types/asset/Asset.ts
+++ b/src/types/asset/Asset.ts
@@ -21,6 +21,8 @@ export type Asset = {
   signedUrl: string;
   source: string;
   sourceUrl: string;
+  extensionId: string;
+  iconUrl?: string;
   metadata?: AssetMetadata;
 };
 

--- a/tests/types/asset/Asset.test.ts
+++ b/tests/types/asset/Asset.test.ts
@@ -25,6 +25,7 @@ describe("Asset", () => {
       signedUrl: "https://example.com/assets/test.jpg",
       sourceUrl: "https://example.com/assets/test.jpg",
       source: "bynder",
+      extensionId: "test-extension-id",
     };
 
     expect(asset.id).toBe("asset-123");
@@ -50,6 +51,7 @@ describe("Asset", () => {
       signedUrl: "https://example.com/assets/test.jpg",
       sourceUrl: "https://example.com/assets/test.jpg",
       source: "bynder",
+      extensionId: "test-extension-id",
       metadata,
     };
 
@@ -110,6 +112,7 @@ describe("ExternalAssetSelection", () => {
           signedUrl: "https://example.com/assets/test.jpg",
           sourceUrl: "https://example.com/assets/test.jpg",
           source: "bynder",
+          extensionId: "test-extension-id",
         },
       ],
     };

--- a/tests/types/extensionRegistration/ExtensionRegistration.test.ts
+++ b/tests/types/extensionRegistration/ExtensionRegistration.test.ts
@@ -92,14 +92,16 @@ describe("ExtensionRegistrationService", () => {
         name: "Asset 1",
         signedUrl: "https://example.com/asset1",
         sourceUrl: "https://example.com/asset1",
-        source: "source1"
+        source: "source1",
+        extensionId: "test-extension-id",
       },
       {
         id: "asset2",
         name: "Asset 2",
         signedUrl: "https://example.com/asset2",
         sourceUrl: "https://example.com/asset2",
-        source: "source2"
+        source: "source2",
+        extensionId: "test-extension-id",
       },
     ];
 


### PR DESCRIPTION
Update Asset type.

## Description

Add `extensionId` and `iconUrl` (optional) properties to `Asset` type.

## Related Issue

https://github.com/adobe/genstudio-extensibility-examples/pull/45

## Motivation and Context

Extension ID will be used to re-toggle selected assets on re-opening to asset selector dialog.
Icon URL will be used to show an icon of the asset's source in the asset details page.

## How Has This Been Tested?

Locally, added this updated SDK to repositories accessing its Asset type and ensuring the new type was recognized.
Ensured existing, deployed apps did not crash when importing an asset without values for these new fields.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.