### PR TITLE
feat: Implement public facing ImportTemplateExtensionService

### DIFF
--- a/docs/api/classes/ImportTemplateExtensionService.md
+++ b/docs/api/classes/ImportTemplateExtensionService.md
@@ -1,0 +1,47 @@
+[**@adobe/genstudio-extensibility-sdk**](../README.md)
+
+***
+
+[@adobe/genstudio-extensibility-sdk](../globals.md) / ImportTemplateExtensionService
+
+# Class: ImportTemplateExtensionService
+
+## Constructors
+
+### new ImportTemplateExtensionService()
+
+> **new ImportTemplateExtensionService**(): [`ImportTemplateExtensionService`](ImportTemplateExtensionService.md)
+
+#### Returns
+
+[`ImportTemplateExtensionService`](ImportTemplateExtensionService.md)
+
+## Methods
+
+### setSelectedTemplate()
+
+> `static` **setSelectedTemplate**(`connection`: `any`, `extensionId`: `string`, `template`: [`Template`](../type-aliases/Template.md)): `void`
+
+Set the selected template
+
+#### Parameters
+
+##### connection
+
+`any`
+
+##### extensionId
+
+`string`
+
+the extension id of the import template add ons
+
+##### template
+
+[`Template`](../type-aliases/Template.md)
+
+the selected template
+
+#### Returns
+
+`void`

--- a/docs/api/classes/ImportTemplateExtensionServiceError.md
+++ b/docs/api/classes/ImportTemplateExtensionServiceError.md
@@ -1,0 +1,137 @@
+[**@adobe/genstudio-extensibility-sdk**](../README.md)
+
+***
+
+[@adobe/genstudio-extensibility-sdk](../globals.md) / ImportTemplateExtensionServiceError
+
+# Class: ImportTemplateExtensionServiceError
+
+## Extends
+
+- `Error`
+
+## Constructors
+
+### new ImportTemplateExtensionServiceError()
+
+> **new ImportTemplateExtensionServiceError**(`message`: `string`): [`ImportTemplateExtensionServiceError`](ImportTemplateExtensionServiceError.md)
+
+#### Parameters
+
+##### message
+
+`string`
+
+#### Returns
+
+[`ImportTemplateExtensionServiceError`](ImportTemplateExtensionServiceError.md)
+
+#### Overrides
+
+`Error.constructor`
+
+## Properties
+
+### cause?
+
+> `optional` **cause**: `unknown`
+
+#### Inherited from
+
+`Error.cause`
+
+***
+
+### message
+
+> **message**: `string`
+
+#### Inherited from
+
+`Error.message`
+
+***
+
+### name
+
+> **name**: `string`
+
+#### Inherited from
+
+`Error.name`
+
+***
+
+### stack?
+
+> `optional` **stack**: `string`
+
+#### Inherited from
+
+`Error.stack`
+
+***
+
+### prepareStackTrace()?
+
+> `static` `optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+Optional override for formatting stack traces
+
+#### Parameters
+
+##### err
+
+`Error`
+
+##### stackTraces
+
+`CallSite`[]
+
+#### Returns
+
+`any`
+
+#### See
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+#### Inherited from
+
+`Error.prepareStackTrace`
+
+***
+
+### stackTraceLimit
+
+> `static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+`Error.stackTraceLimit`
+
+## Methods
+
+### captureStackTrace()
+
+> `static` **captureStackTrace**(`targetObject`: `object`, `constructorOpt`?: `Function`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+##### targetObject
+
+`object`
+
+##### constructorOpt?
+
+`Function`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Error.captureStackTrace`

--- a/docs/api/globals.md
+++ b/docs/api/globals.md
@@ -10,6 +10,8 @@
 
 ## Classes
 
+- [ImportTemplateExtensionService](classes/ImportTemplateExtensionService.md)
+- [ImportTemplateExtensionServiceError](classes/ImportTemplateExtensionServiceError.md)
 - [PromptExtensionService](classes/PromptExtensionService.md)
 - [PromptExtensionServiceError](classes/PromptExtensionServiceError.md)
 - [SelectContentExtensionService](classes/SelectContentExtensionService.md)
@@ -21,6 +23,7 @@
 
 - [Experience](interfaces/Experience.md)
 - [ExperienceField](interfaces/ExperienceField.md)
+- [ImportTemplateExtensionApi](interfaces/ImportTemplateExtensionApi.md)
 - [PromptExtensionApi](interfaces/PromptExtensionApi.md)
 - [SelectContentExtensionApi](interfaces/SelectContentExtensionApi.md)
 - [ValidationExtensionApi](interfaces/ValidationExtensionApi.md)

--- a/docs/api/interfaces/ImportTemplateExtensionApi.md
+++ b/docs/api/interfaces/ImportTemplateExtensionApi.md
@@ -1,0 +1,43 @@
+[**@adobe/genstudio-extensibility-sdk**](../README.md)
+
+***
+
+[@adobe/genstudio-extensibility-sdk](../globals.md) / ImportTemplateExtensionApi
+
+# Interface: ImportTemplateExtensionApi
+
+## Extends
+
+- `VirtualApi`
+
+## Indexable
+
+\[`key`: `string`\]: `object` \| (...`args`: `unknown`[]) => `unknown`
+
+## Properties
+
+### api
+
+> **api**: \{ `importTemplateExtension`: \{ `setSelectedTemplate`: (`extensionId`: `string`, `template`: [`Template`](../type-aliases/Template.md)) => `void`; \}; \}
+
+#### importTemplateExtension
+
+> **importTemplateExtension**: \{ `setSelectedTemplate`: (`extensionId`: `string`, `template`: [`Template`](../type-aliases/Template.md)) => `void`; \}
+
+##### importTemplateExtension.setSelectedTemplate()
+
+> **setSelectedTemplate**: (`extensionId`: `string`, `template`: [`Template`](../type-aliases/Template.md)) => `void`
+
+###### Parameters
+
+###### extensionId
+
+`string`
+
+###### template
+
+[`Template`](../type-aliases/Template.md)
+
+###### Returns
+
+`void`

--- a/src/services/import-template-extension-service.ts
+++ b/src/services/import-template-extension-service.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { VirtualApi } from "@adobe/uix-core";
+import { Template } from "../types";
+
+export interface ImportTemplateExtensionApi extends VirtualApi {
+  api: {
+    importTemplateExtension: {
+      setSelectedTemplate: (extensionId: string, template: Template) => void;
+    };
+  };
+}
+
+export class ImportTemplateExtensionServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImportTemplateExtensionServiceError";
+  }
+}
+
+export class ImportTemplateExtensionService {
+  /**
+   * Set the selected template
+   * @param extensionId - the extension id of the import template add ons
+   * @param template - the selected template
+   */
+  static setSelectedTemplate(
+    connection: any,
+    extensionId: string,
+    template: Template,
+  ): void {
+    if (!connection) {
+      throw new ImportTemplateExtensionServiceError("Connection is required to set selected template");
+    }
+
+    // @ts-ignore Remote API is handled through postMessage
+    return connection.host.api.importTemplateExtension.setSelectedTemplate(
+      extensionId,
+      template,
+    );
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -13,3 +13,4 @@ governing permissions and limitations under the License.
 export * from "./validation-extension-service";
 export * from "./prompt-extension-service";
 export * from "./select-content-extension-service";
+export * from "./import-template-extension-service";

--- a/tests/services/import-template-extension-service.test.ts
+++ b/tests/services/import-template-extension-service.test.ts
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ImportTemplateExtensionService, ImportTemplateExtensionServiceError, ImportTemplateExtensionApi } from '../../src/services/import-template-extension-service';
+import { GuestUI } from '@adobe/uix-guest';
+import { Template } from '../../src/types';
+
+const createMockConnection = (
+  setSelectedTemplateMock?: jest.Mock
+) => ({
+  host: {
+    api: {
+      importTemplateExtension: {
+        setSelectedTemplate: setSelectedTemplateMock || jest.fn()
+      }
+    }
+  }
+} as unknown as GuestUI<ImportTemplateExtensionApi>);
+
+describe('ImportTemplateExtensionService', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const mockTemplate: Template = {
+    id: 'tpl-123',
+    title: 'Test Template',
+    content: 'Hello, {{name}}',
+    mapping: {
+      name: 'user.name'
+    }
+  };
+
+  describe('setSelectedTemplate', () => {
+    it('should set selected template successfully', () => {
+      const mockSetSelectedTemplate = jest.fn();
+      const mockConnection = createMockConnection(mockSetSelectedTemplate);
+      const extensionId = 'test-extension-id';
+
+      ImportTemplateExtensionService.setSelectedTemplate(mockConnection, extensionId, mockTemplate);
+
+      expect(mockSetSelectedTemplate).toHaveBeenCalledWith(extensionId, mockTemplate);
+      expect(mockSetSelectedTemplate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw ImportTemplateExtensionServiceError if connection is missing', () => {
+      const extensionId = 'test-extension-id';
+
+      expect(() => ImportTemplateExtensionService.setSelectedTemplate(null, extensionId, mockTemplate))
+        .toThrow(ImportTemplateExtensionServiceError);
+
+      expect(() => ImportTemplateExtensionService.setSelectedTemplate(null, extensionId, mockTemplate))
+        .toThrow('Connection is required to set selected template');
+    });
+
+    it('should handle empty extensionId', () => {
+      const mockSetSelectedTemplate = jest.fn();
+      const mockConnection = createMockConnection(mockSetSelectedTemplate);
+      const extensionId = '';
+
+      ImportTemplateExtensionService.setSelectedTemplate(mockConnection, extensionId, mockTemplate);
+
+      expect(mockSetSelectedTemplate).toHaveBeenCalledWith(extensionId, mockTemplate);
+    });
+
+    it('should handle minimal template mapping', () => {
+      const mockSetSelectedTemplate = jest.fn();
+      const mockConnection = createMockConnection(mockSetSelectedTemplate);
+      const extensionId = 'test-extension-id';
+      const minimalTemplate: Template = {
+        id: 'tpl-456',
+        title: 'Empty Mapping',
+        content: 'Static content',
+        mapping: {}
+      };
+
+      ImportTemplateExtensionService.setSelectedTemplate(mockConnection, extensionId, minimalTemplate);
+
+      expect(mockSetSelectedTemplate).toHaveBeenCalledWith(extensionId, minimalTemplate);
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create a service that template extension apps will use to set the external template to use in GenStudio.

## Related Issue

https://jira.corp.adobe.com/browse/GS-17679

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.