### PR TITLE
fix: Add metadata fields for external template

### DIFF
--- a/docs/api/globals.md
+++ b/docs/api/globals.md
@@ -56,6 +56,7 @@
 - [Product](type-aliases/Product.md)
 - [SectionGenerationContext](type-aliases/SectionGenerationContext.md)
 - [Template](type-aliases/Template.md)
+- [TemplateMetadata](type-aliases/TemplateMetadata.md)
 - [Toggle](type-aliases/Toggle.md)
 - [TranslationItem](type-aliases/TranslationItem.md)
 - [TranslationMessage](type-aliases/TranslationMessage.md)

--- a/docs/api/type-aliases/Template.md
+++ b/docs/api/type-aliases/Template.md
@@ -14,18 +14,28 @@
 
 > **content**: `string`
 
+Raw HTML content of the template
+
 ### id
 
 > **id**: `string`
+
+Unique identifier for the template
 
 ### mapping
 
 > **mapping**: [`Mapping`](Mapping.md)
 
+Mapping of Handlebars variables to GenStudio variables
+
 ### metadata?
 
 > `optional` **metadata**: [`TemplateMetadata`](TemplateMetadata.md)
 
+Metadata about the template
+
 ### title
 
 > **title**: `string`
+
+Title of the template

--- a/docs/api/type-aliases/Template.md
+++ b/docs/api/type-aliases/Template.md
@@ -6,7 +6,7 @@
 
 # Type Alias: Template
 
-> **Template**: \{ `content`: `string`; `id`: `string`; `mapping`: [`Mapping`](Mapping.md); `title`: `string`; \}
+> **Template**: \{ `content`: `string`; `id`: `string`; `mapping`: [`Mapping`](Mapping.md); `metadata`: [`TemplateMetadata`](TemplateMetadata.md); `title`: `string`; \}
 
 ## Type declaration
 
@@ -21,6 +21,10 @@
 ### mapping
 
 > **mapping**: [`Mapping`](Mapping.md)
+
+### metadata?
+
+> `optional` **metadata**: [`TemplateMetadata`](TemplateMetadata.md)
 
 ### title
 

--- a/docs/api/type-aliases/TemplateMetadata.md
+++ b/docs/api/type-aliases/TemplateMetadata.md
@@ -14,6 +14,10 @@
 
 > **source**: `string`
 
+Source of the template
+
 ### url?
 
 > `optional` **url**: `string`
+
+URL of the template

--- a/docs/api/type-aliases/TemplateMetadata.md
+++ b/docs/api/type-aliases/TemplateMetadata.md
@@ -6,9 +6,13 @@
 
 # Type Alias: TemplateMetadata
 
-> **TemplateMetadata**: \{ `source`: `string`; `url`: `string`; \}
+> **TemplateMetadata**: \{ `[key: string]`: `any`;  `source`: `string`; `url`: `string`; \}
 
 ## Type declaration
+
+## Index Signature
+
+\[`key`: `string`\]: `any`
 
 ### source
 

--- a/docs/api/type-aliases/TemplateMetadata.md
+++ b/docs/api/type-aliases/TemplateMetadata.md
@@ -1,0 +1,19 @@
+[**@adobe/genstudio-extensibility-sdk**](../README.md)
+
+***
+
+[@adobe/genstudio-extensibility-sdk](../globals.md) / TemplateMetadata
+
+# Type Alias: TemplateMetadata
+
+> **TemplateMetadata**: \{ `source`: `string`; `url`: `string`; \}
+
+## Type declaration
+
+### source
+
+> **source**: `string`
+
+### url?
+
+> `optional` **url**: `string`

--- a/src/types/template/Template.ts
+++ b/src/types/template/Template.ts
@@ -12,9 +12,15 @@ governing permissions and limitations under the License.
 
 export type Mapping = Record<string, string>;
 
+export type TemplateMetadata = {
+    source: string;
+    url?: string;
+};
+
 export type Template = {
     id: string;
     title: string;
     content: string;
     mapping: Mapping;
-}
+    metadata?: TemplateMetadata;
+};

--- a/src/types/template/Template.ts
+++ b/src/types/template/Template.ts
@@ -17,6 +17,8 @@ export type TemplateMetadata = {
     source: string;
     /** URL of the template */
     url?: string;
+    /** Additional metadata */
+    [key: string]: any;
 };
 
 export type Template = {

--- a/src/types/template/Template.ts
+++ b/src/types/template/Template.ts
@@ -13,14 +13,21 @@ governing permissions and limitations under the License.
 export type Mapping = Record<string, string>;
 
 export type TemplateMetadata = {
+    /** Source of the template */
     source: string;
+    /** URL of the template */
     url?: string;
 };
 
 export type Template = {
+    /** Unique identifier for the template */
     id: string;
+    /** Title of the template */
     title: string;
+    /** Raw HTML content of the template */
     content: string;
+    /** Mapping of Handlebars variables to GenStudio variables */
     mapping: Mapping;
+    /** Metadata about the template */
     metadata?: TemplateMetadata;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added metadata fields for the template that we want to store in GenStudio.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/GS-18733

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.