### PR TITLE
refactor: update FragmentSwapExtensionService and SelectContentExtension

### DIFF
--- a/docs/api/classes/FragmentSwapExtensionService.md
+++ b/docs/api/classes/FragmentSwapExtensionService.md
@@ -98,36 +98,6 @@ Error if connection is missing
 
 ***
 
-### open()
-
-> `static` **open**(`connection`: `any`, `extensionId`: `string`): `void`
-
-Opens the swap field extension dialog
-
-#### Parameters
-
-##### connection
-
-`any`
-
-The guest connection to the host
-
-##### extensionId
-
-`string`
-
-The ID of the extension to open
-
-#### Returns
-
-`void`
-
-#### Throws
-
-Error if connection is missing
-
-***
-
 ### setSwapValue()
 
 > `static` **setSwapValue**(`connection`: `any`, `value`: `string`): `void`

--- a/docs/api/classes/SelectContentExtensionService.md
+++ b/docs/api/classes/SelectContentExtensionService.md
@@ -50,7 +50,7 @@ the selected assets
 
 ### sync()
 
-> `static` **sync**(`connection`: `any`, `extensionId`: `string`): \{ `allowedFileTypes`: `string`[]; `selectedAssets`: [`Asset`](../type-aliases/Asset.md)[]; `selectionLimit`: `number`; \}
+> `static` **sync**(`connection`: `any`, `extensionId`: `string`): `Promise`\<\{ `allowedFileTypes`: `string`[]; `selectedAssets`: [`Asset`](../type-aliases/Asset.md)[]; `selectionLimit`: `number`; \}\>
 
 Sync the selected assets
 
@@ -68,18 +68,6 @@ The guest connection to the host
 
 #### Returns
 
-\{ `allowedFileTypes`: `string`[]; `selectedAssets`: [`Asset`](../type-aliases/Asset.md)[]; `selectionLimit`: `number`; \}
+`Promise`\<\{ `allowedFileTypes`: `string`[]; `selectedAssets`: [`Asset`](../type-aliases/Asset.md)[]; `selectionLimit`: `number`; \}\>
 
 the current selected assets and the total count of left assets
-
-##### allowedFileTypes
-
-> **allowedFileTypes**: `string`[]
-
-##### selectedAssets
-
-> **selectedAssets**: [`Asset`](../type-aliases/Asset.md)[]
-
-##### selectionLimit
-
-> **selectionLimit**: `number`

--- a/docs/api/interfaces/FragmentSwapExtensionApi.md
+++ b/docs/api/interfaces/FragmentSwapExtensionApi.md
@@ -18,19 +18,11 @@
 
 ### api
 
-> **api**: \{ `fragmentSwapExtension`: \{ `close`: () => `void`; `getExperience`: () => `Promise`\<[`Experience`](Experience.md)\>; `getGenerationContext`: () => `Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>; `getSelectedField`: () => `Promise`\<[`FieldUpdate`](../type-aliases/FieldUpdate.md)\>; `open`: (`extensionId`: `string`) => `void`; `setSwapValue`: (`value`: `string`) => `void`; \}; \}
+> **api**: \{ `fragmentSwapExtension`: \{ `getExperience`: () => `Promise`\<[`Experience`](Experience.md)\>; `getGenerationContext`: () => `Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>; `getSelectedField`: () => `Promise`\<[`FieldUpdate`](../type-aliases/FieldUpdate.md)\>; `setSwapValue`: (`value`: `string`) => `void`; \}; \}
 
 #### fragmentSwapExtension
 
-> **fragmentSwapExtension**: \{ `close`: () => `void`; `getExperience`: () => `Promise`\<[`Experience`](Experience.md)\>; `getGenerationContext`: () => `Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>; `getSelectedField`: () => `Promise`\<[`FieldUpdate`](../type-aliases/FieldUpdate.md)\>; `open`: (`extensionId`: `string`) => `void`; `setSwapValue`: (`value`: `string`) => `void`; \}
-
-##### fragmentSwapExtension.close()
-
-> **close**: () => `void`
-
-###### Returns
-
-`void`
+> **fragmentSwapExtension**: \{ `getExperience`: () => `Promise`\<[`Experience`](Experience.md)\>; `getGenerationContext`: () => `Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>; `getSelectedField`: () => `Promise`\<[`FieldUpdate`](../type-aliases/FieldUpdate.md)\>; `setSwapValue`: (`value`: `string`) => `void`; \}
 
 ##### fragmentSwapExtension.getExperience()
 
@@ -55,20 +47,6 @@
 ###### Returns
 
 `Promise`\<[`FieldUpdate`](../type-aliases/FieldUpdate.md)\>
-
-##### fragmentSwapExtension.open()
-
-> **open**: (`extensionId`: `string`) => `void`
-
-###### Parameters
-
-###### extensionId
-
-`string`
-
-###### Returns
-
-`void`
 
 ##### fragmentSwapExtension.setSwapValue()
 

--- a/src/services/select-content-extension-service.ts
+++ b/src/services/select-content-extension-service.ts
@@ -35,14 +35,14 @@ export class SelectContentExtensionService {
    * @param connection - The guest connection to the host
    * @returns the current selected assets and the total count of left assets
    */
-  static sync(
+  static async sync(
     connection: any,
     extensionId: string,
-  ): {
+  ): Promise<{
     selectedAssets: Asset[];
     selectionLimit: number;
     allowedFileTypes: string[];
-  } {
+  }> {
     if (!connection) {
       throw new SelectContentExtensionServiceError(
         "Connection is required to sync selected assets",

--- a/tests/services/select-content-extension-service.test.ts
+++ b/tests/services/select-content-extension-service.test.ts
@@ -100,12 +100,12 @@ describe("SelectContentExtensionService", () => {
 
     it("should throw SelectContentExtensionServiceError if connection is missing", async () => {
       // @ts-ignore Testing null case explicitly
-      expect(() =>
+      await expect(
         SelectContentExtensionService.sync(null, "test-extension-id"),
-      ).toThrow(SelectContentExtensionServiceError);
-      expect(() =>
+      ).rejects.toThrow(SelectContentExtensionServiceError);
+      await expect(
         SelectContentExtensionService.sync(null, "test-extension-id"),
-      ).toThrow("Connection is required to sync selected assets");
+      ).rejects.toThrow("Connection is required to sync selected assets");
     });
 
     it("should handle empty selected assets array", async () => {


### PR DESCRIPTION
- Removed the `open` method from FragmentSwapExtensionService documentation.
- Updated the `sync` method in SelectContentExtensionService to return a Promise instead of a direct object.
- Adjusted related documentation to reflect these changes.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.