### PR TITLE
feat: Multi channel support for Experiences

### DIFF
--- a/docs/api/interfaces/Experience.md
+++ b/docs/api/interfaces/Experience.md
@@ -11,9 +11,9 @@ An Experience is a container for various fields that define its characteristics.
 
 ## Properties
 
-### channels
+### channels?
 
-> **channels**: [`Channel`](../type-aliases/Channel.md)[]
+> `optional` **channels**: [`Channel`](../type-aliases/Channel.md)[]
 
 Channels associated with the experience
 

--- a/docs/api/interfaces/Experience.md
+++ b/docs/api/interfaces/Experience.md
@@ -11,6 +11,14 @@ An Experience is a container for various fields that define its characteristics.
 
 ## Properties
 
+### channels
+
+> **channels**: [`Channel`](../type-aliases/Channel.md)[]
+
+Channels associated with the experience
+
+***
+
 ### experienceFields
 
 > **experienceFields**: `Record`\<`string`, [`ExperienceField`](ExperienceField.md)\>

--- a/docs/api/type-aliases/GenerationContext.md
+++ b/docs/api/type-aliases/GenerationContext.md
@@ -6,7 +6,7 @@
 
 # Type Alias: GenerationContext
 
-> **GenerationContext**: \{ `additionalContexts`: [`AdditionalContext`](AdditionalContext.md)\<`any`\>[]; `brand`: [`Brand`](Brand.md); `id`: `string`; `locale`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; `sourceExperience`: [`Experience`](../interfaces/Experience.md); `userPrompt`: `string`; \}
+> **GenerationContext**: \{ `additionalContexts`: [`AdditionalContext`](AdditionalContext.md)\<`any`\>[]; `brand`: [`Brand`](Brand.md); `channel`: [`Channel`](Channel.md); `id`: `string`; `locale`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; `sourceExperience`: [`Experience`](../interfaces/Experience.md); `userPrompt`: `string`; \}
 
 ## Type declaration
 
@@ -17,6 +17,14 @@
 ### brand?
 
 > `optional` **brand**: [`Brand`](Brand.md)
+
+### ~~channel?~~
+
+> `optional` **channel**: [`Channel`](Channel.md)
+
+#### Deprecated
+
+Use [Experience.channels](../interfaces/Experience.md#channels) instead
 
 ### id
 

--- a/docs/api/type-aliases/GenerationContext.md
+++ b/docs/api/type-aliases/GenerationContext.md
@@ -6,7 +6,7 @@
 
 # Type Alias: GenerationContext
 
-> **GenerationContext**: \{ `additionalContexts`: [`AdditionalContext`](AdditionalContext.md)\<`any`\>[]; `brand`: [`Brand`](Brand.md); `channel`: [`Channel`](Channel.md); `id`: `string`; `locale`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; `sourceExperience`: [`Experience`](../interfaces/Experience.md); `userPrompt`: `string`; \}
+> **GenerationContext**: \{ `additionalContexts`: [`AdditionalContext`](AdditionalContext.md)\<`any`\>[]; `brand`: [`Brand`](Brand.md); `id`: `string`; `locale`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; `sourceExperience`: [`Experience`](../interfaces/Experience.md); `userPrompt`: `string`; \}
 
 ## Type declaration
 
@@ -17,10 +17,6 @@
 ### brand?
 
 > `optional` **brand**: [`Brand`](Brand.md)
-
-### channel?
-
-> `optional` **channel**: [`Channel`](Channel.md)
 
 ### id
 

--- a/src/types/experience/Experience.ts
+++ b/src/types/experience/Experience.ts
@@ -22,7 +22,7 @@ export interface Experience {
   /** Unique identifier for the experience */
   id: string;
   /** Channels associated with the experience */
-  channels: Channel[];
+  channels?: Channel[];
   /** Collection of experience fields stored as key-value pairs */
   experienceFields: Record<string, ExperienceField>;
   /** Template associated with the experience */

--- a/src/types/experience/Experience.ts
+++ b/src/types/experience/Experience.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 /* this file defines types and interfaces that are considered as Experience api for extension consumers */
 
+import { Channel } from "../channel/Channel";
 import { Template } from "../template";
 
 /**
@@ -20,6 +21,8 @@ import { Template } from "../template";
 export interface Experience {
   /** Unique identifier for the experience */
   id: string;
+  /** Channels associated with the experience */
+  channels: Channel[];
   /** Collection of experience fields stored as key-value pairs */
   experienceFields: Record<string, ExperienceField>;
   /** Template associated with the experience */

--- a/src/types/experience/ExperienceWithVariant.ts
+++ b/src/types/experience/ExperienceWithVariant.ts
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 /* this file defines types and interfaces that are considered as Experience api for extension consumers */
 
+import { Channel } from "../channel/Channel";
+
 /**
  * Metadata describing a variant's size and aspect ratio.
  */
@@ -50,6 +52,8 @@ export type Variant = {
 export type ExperienceWithVariant = {
   /** Unique identifier for the experience */
   id: string;
+  /** Channels associated with the experience */
+  channels?: Channel[];
   /** Metadata for the experience */
   metadata: {
     /** Basic info about the experience */

--- a/src/types/generationContext/GenerationContext.ts
+++ b/src/types/generationContext/GenerationContext.ts
@@ -56,6 +56,10 @@ export type SectionGenerationContext = {
 export type GenerationContext = {
   id: string;
   userPrompt: string;
+  /**
+   * @deprecated Use {@link Experience.channels} instead
+   */
+  channel?: Channel;
   locale?: string;
   brand?: Brand;
   product?: Product;

--- a/src/types/generationContext/GenerationContext.ts
+++ b/src/types/generationContext/GenerationContext.ts
@@ -56,7 +56,6 @@ export type SectionGenerationContext = {
 export type GenerationContext = {
   id: string;
   userPrompt: string;
-  channel?: Channel;
   locale?: string;
   brand?: Brand;
   product?: Product;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -271,6 +271,7 @@ describe("SDK Exports", () => {
       const generationContext: GenerationContext = {
         id: "test",
         userPrompt: "my user prompt",
+        channel: Email,
         brand,
         product,
         persona,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -95,10 +95,20 @@ describe("SDK Exports", () => {
 
       const experience: Experience = {
         id: "test",
+        channels: [
+          { id: "email", name: "Email" },
+          { id: "meta", name: "Meta" },
+          { id: "display", name: "Display" },
+        ],
         experienceFields: { test: field },
       };
 
       expect(experience.id).toBe("test");
+      expect(experience.channels).toEqual([
+        { id: "email", name: "Email" },
+        { id: "meta", name: "Meta" },
+        { id: "display", name: "Display" },
+      ]);
       expect(experience.experienceFields.test).toEqual(field);
     });
 
@@ -261,7 +271,6 @@ describe("SDK Exports", () => {
       const generationContext: GenerationContext = {
         id: "test",
         userPrompt: "my user prompt",
-        channel: Email,
         brand,
         product,
         persona,


### PR DESCRIPTION
Adds a `channels` field to `Experience`.
Multiple channels can be added to an experience.

Deprecate the `channel` field in Generation Context.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.