### PR TITLE
chore: update changelog for version 4.x

### DIFF
--- a/docs/changelog/v4.md
+++ b/docs/changelog/v4.md
@@ -1,5 +1,48 @@
 # [4.x]
 
+## 2026-05-20
+
+### Bug Fixes
+
+- Fixed a host-side bug where channel information was not provided to validation extensions for LinkedIn ads created with HTML templates. No SDK changes required — extensions using `ValidationExtensionService.getExperiences()` will now receive correct channel data automatically.
+
+## [4.6.0] - 2026-04-27
+
+### Changes
+
+- `FragmentSwapExtensionService` gains `getSelectedField()` — returns the field currently selected for swapping, including its `experienceId`, `name`, and current value.
+- `FragmentSwapExtensionService` regains `open()` and `close()` methods (re-added after being removed in 4.5.1).
+
+## [4.5.1] - 2026-04-24
+
+### Changes
+
+- Removed unused `open()` and `close()` methods from `FragmentSwapExtensionService`.
+
+## [4.5.0] - 2026-04-23
+
+### New Features
+
+#### Fragment Swap Extension
+
+New `FragmentSwapExtensionService` for swapping field content within an experience:
+
+- `getExperience()` — retrieves the current experience context
+- `getGenerationContext()` — retrieves the generation context
+- `setSwapValue(value)` — sets the replacement value for the selected field
+
+## [4.4.0] - 2026-04-09
+
+### New Features
+
+- `ValidationExtensionService.updateField(connection, fieldUpdate)` — updates a field value on the canvas. Accepts a `FieldUpdate` payload describing which field to change and the new value.
+
+## [4.3.2] - 2026-04-06
+
+### Changes
+
+- Removed `getCanvasType()` from `ValidationExtensionService`.
+
 ## [4.3.1] - 2026-02-12
 
 ### Changes


### PR DESCRIPTION
- Added a new entry for the bug fix on LinkedIn ads validation extensions.
- Documented changes in FragmentSwapExtensionService, including the reintroduction of `open()` and `close()` methods and the addition of `getSelectedField()`.
- Updated previous version entries for clarity and consistency.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.