### PR TITLE
docs: add LinkedIn channel info bug fix entry to v4 changelog

### DIFF
--- a/docs/changelog/v4.md
+++ b/docs/changelog/v4.md
@@ -1,12 +1,10 @@
 # [4.x]
 
-## 2026-05-20
+## [4.6.0] - 2026-04-27
 
 ### Bug Fixes
 
-- Fixed a host-side bug where channel information was not provided to validation extensions for LinkedIn ads created with HTML templates. No SDK changes required — extensions using `ValidationExtensionService.getExperiences()` will now receive correct channel data automatically.
-
-## [4.6.0] - 2026-04-27
+- **LinkedIn ads channel info missing in validation extensions (all SDK versions):** Customers building validation extensions were blocked from accessing LinkedIn channel information for ads created with HTML templates — `ValidationExtensionService.getExperiences()` returned incomplete data, preventing extensions from reading LinkedIn-specific context. This fix unblocks customers, who can now retrieve full LinkedIn channel information and use it to power channel-aware validation and display channel context. Fixed on the host side; no SDK update required, applies to all SDK versions.
 
 ### Changes
 


### PR DESCRIPTION
## Summary

- Adds a bug fix entry under `[4.6.0]` in the v4 changelog documenting the host-side fix for LinkedIn channel information not being provided to validation extensions for ads created with HTML templates
- Clarifies customer impact: extensions were blocked from reading LinkedIn channel context via `ValidationExtensionService.getExperiences()`; the fix unblocks them across all SDK versions
- No SDK code changes — documentation only

## Test plan

- [ ] Review changelog entry for accuracy and clarity