### PR TITLE
feat: add importTemplate.supportsFieldReview option to AppOptions

### DIFF
--- a/src/types/app/AppMetadata.ts
+++ b/src/types/app/AppMetadata.ts
@@ -38,6 +38,13 @@ export type AppOptions = {
      */
     cors: boolean;
   };
+  importTemplate?: {
+    /**
+     * Indicates that this extension supports the field auto-detect and review step
+     * during template import.
+     */
+    supportsFieldReview?: boolean;
+  };
 };
 
 /** App Metadata */

--- a/tests/types/app/AppMetadata.test.ts
+++ b/tests/types/app/AppMetadata.test.ts
@@ -56,11 +56,15 @@ describe("AppMetadata types", () => {
         selectContent: {
           cors: true,
         },
+        importTemplate: {
+          supportsFieldReview: true,
+        },
       },
     };
     expect(metadata).toBeDefined();
     expect(metadata.options?.validation?.singleExperienceViewMode).toBe(true);
     expect(metadata.options?.selectContent?.cors).toBe(true);
+    expect(metadata.options?.importTemplate?.supportsFieldReview).toBe(true);
   });
 
   it("should compile with partial options", () => {


### PR DESCRIPTION
Lets extensions self-declare support for the field auto-detect and review step during template import, instead of GenStudio hardcoding vendor names.

  ## Description

  Adds a new `importTemplate.supportsFieldReview?: boolean` option to `AppOptions` in `src/types/app/AppMetadata.ts`. Extensions can now set this flag in their `AppMetadata` to declare that they support the field auto-detect and review step
  during template import.

  Today, GenStudio decides which vendors get this step using a hardcoded list (`AUTO_DETECT_TEMPLATE_SOURCES`) matched against the template source/tab label. That requires a GenStudio code change and release every time a new third-party
  integration wants to opt in, and forces GenStudio to maintain a running list of vendor identities. This flag lets extensions declare the capability themselves, following the same per-feature options pattern already used for `validation` and
  `selectContent`.

  ## Related Issue

  Adobe-internal JIRA: GS-37445 (no public GitHub issue).

  ## Motivation and Context

  New third-party template integrations currently can't get field auto-detect/review support without a GenStudio code change and release to add their name to a hardcoded list. Moving the capability declaration into extension metadata lets any
  extension opt in with zero GenStudio code changes.

  ## How Has This Been Tested?

  - Added a test case in `tests/types/app/AppMetadata.test.ts` asserting `AppMetadata` compiles with `options.importTemplate.supportsFieldReview` set and that the value round-trips correctly.
  - Ran the full test suite (`npx jest`): 13 suites / 122 tests passing.
  - Ran `npm run build` (ESM + CJS `tsc` builds): compiles cleanly with no type errors.

  ## Screenshots (if appropriate):

  N/A — type-only change.

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  A couple of items I left for you to confirm/check yourself:
  - CLA checkbox — I can't confirm on your behalf whether you've signed it.
  - Documentation — left unchecked since I didn't touch docs/changelog/v4.md; worth adding an entry there before merge, consistent with how past feature PRs (e.g. #104, #91) have done it. Want me to add that changelog entry now?